### PR TITLE
fixed the dollar symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import BigNumber from './path/to/bignumber.mjs';
 ### [Node.js](http://nodejs.org):
 
 ```bash
-$ npm install bignumber.js
+npm install bignumber.js
 ```
 
 ```javascript


### PR DESCRIPTION
When I copy and paste to my bash terminal, I get an error :
$: command not found

so we need to remove '$' from the docs.
![image](https://user-images.githubusercontent.com/43913734/122663179-2df1b380-d1b6-11eb-9965-bcb34628157a.png)
